### PR TITLE
TLN-6300_Allow_No_Annotations

### DIFF
--- a/src/JsonSerializer.php
+++ b/src/JsonSerializer.php
@@ -125,7 +125,7 @@ final class JsonSerializer extends Serializer
                     ->getPropertyAnnotation($reflectionProperty, SerializedName::CLASS_NAME)
                     ->getValue();
             } catch (PropertyAnnotationNotFound $e) {
-                throw new \InvalidArgumentException('Must have SerializedName annotation.', 0, $e);
+                continue;
             }
             $properties[] = \json_encode($serializedName) . ':'
                 . self::serializeValue($reflectionProperty->getValue($entity), $recursionLimit);

--- a/src/Serializer.php
+++ b/src/Serializer.php
@@ -107,7 +107,7 @@ class Serializer
                     ->getPropertyAnnotation($reflectionProperty, SerializedName::CLASS_NAME)
                     ->getValue();
             } catch (PropertyAnnotationNotFound $e) {
-                throw new \InvalidArgumentException('Type and SerializedName annotations must be defined.', 0, $e);
+                continue;
             }
             if (isset($value[$serializedName])) {
                 $reflectionProperty->setAccessible(true);

--- a/tests/Unit/Entities/Entity1.php
+++ b/tests/Unit/Entities/Entity1.php
@@ -17,6 +17,9 @@ class Entity1
 {
     const CLASS_NAME = __CLASS__;
 
+    /** @var string */
+    private $propertyWithNoAnnotations;
+
     /**
      * @var null
      * @Serializer\SerializedName("null")


### PR DESCRIPTION
Instead of throwing an error when no annotations are found, just continuing to the next property.